### PR TITLE
Fix baseline to be able to use 'MotionMoose' group

### DIFF
--- a/BaselineOfMoTion/BaselineOfMoTion.class.st
+++ b/BaselineOfMoTion/BaselineOfMoTion.class.st
@@ -8,11 +8,12 @@ Class {
 BaselineOfMoTion >> baseline: spec [
 
 	<baseline>
-	spec for: #common do: [ 
+	spec for: #common do: [
 		spec
 			package: #MoTion;
-			package: #'MoTion-Tests' with: [ spec requires: #( 'MoTion' ) ].
-		spec for: #MooseX do: [ spec package: 'MoTion-Moose' ].
-		spec group: 'MoTionMoose' with: #( 'MoTion' 'MoTion-Tests' 'MoTion-Moose').
-		spec group: 'default' with: #( 'MoTion' 'MoTion-Tests' ) ]
+			package: #'MoTion-Tests' with: [ spec requires: #( 'MoTion' ) ];
+			package: #'MoTion-Moose' with: [ spec requires: #( 'MoTion' ) ].
+
+		spec group: 'default' with: #( 'MoTion' 'MoTion-Tests' ).
+		spec group: 'MoTionMoose' with: #( 'default' 'MoTion-Moose' ) ]
 ]


### PR DESCRIPTION
when loading with Metacello.

This should work now: 
```Smalltalk
Metacello new
    baseline: 'MoTion';
    repository: 'github://AlessHosry/MoTion:main';
    load: 'MoTionMoose'
```